### PR TITLE
docs : lunaa : Update according to latest device firmware RMX3360_13.1.0.161(EX01)

### DIFF
--- a/10/lunaa.md
+++ b/10/lunaa.md
@@ -1,6 +1,6 @@
 ### Pre-installation:
 
-*  **Realme UI 4 13 - 13.1.0.159(EX01) firmware is required** 
+*  **Realme UI 4 13 - 13.1.0.161(EX01) firmware is required** 
 * Optional gapps (from download page, gapps button)
 * Optional KernelSU apk (get it on [release page](https://github.com/tiann/KernelSU/releases) from their GitHub - click "show all assets" to see the apk)
 


### PR DESCRIPTION
Recently OEM has pushed update for the device. Thus all the proprietary-files are updated , and it is needed to use the latest firmware. So mentioned it in the installation docs for the users