### PR TITLE
a20: Japanese model is not supported

### DIFF
--- a/10/a20.md
+++ b/10/a20.md
@@ -3,7 +3,9 @@
 * This will NOT work on the A20e or A20s  
 * USB-C cable that can do data transfer  
 * A computer running Windows XP or later  
-* A MicroSD card that's at least 2GB  
+* A MicroSD card that's at least 2GB
+
+Do note the Japanese model of the Galaxy A20 (SCV46) is not supported, as it's actually a rebranded A20e.
 
 ### Unlocking bootloader
 This **WILL** factory reset your phone. Back up any data before continuing.  

--- a/11/a20.md
+++ b/11/a20.md
@@ -4,6 +4,8 @@
 * USB-C cable that can do data transfer  
 * A computer running Windows 10 or later which has ADB installed
 
+Do note the Japanese model of the Galaxy A20 (SCV46) is not supported, as it's actually a rebranded A20e.
+
 ### Unlocking bootloader
 This **WILL** factory reset your phone. Back up any data before continuing.  
 * Open Settings, and go to About phone -> Software information  


### PR DESCRIPTION
Someone on XDA recently told me crDroid 10 wasn't working on their Japanese Galaxy A20, and it turns out the Japanese A20 is actually an A20e, which Samsung threw the standard A20 naming onto for some reason. I hate Samsung...