### PR TITLE
Pixel 3: GApps are not supported.

### DIFF
--- a/11/blueline.md
+++ b/11/blueline.md
@@ -1,3 +1,5 @@
+GApps are **NOT** supported! The Pixel 3's partitions are too small to store both crDroid and GApps. Installing GApps will result in your phone bootlooping, and support will not be provided if you attempt to install them.
+
 ### Pre-installation:
 You will need to have a computer with the Android Platform Tools installed. See XDA's guide for installing the platform tools: https://www.xda-developers.com/install-adb-windows-macos-linux/
 

--- a/11/bonito.md
+++ b/11/bonito.md
@@ -1,3 +1,5 @@
+GApps are **NOT** supported! The Pixel 3a XL's partitions are too small to store both crDroid and GApps. Installing GApps will result in your phone bootlooping, and support will not be provided if you attempt to install them.
+
 ### Pre-installation:
 You will need to have a computer with the Android Platform Tools installed. See XDA's guide for installing the platform tools: https://www.xda-developers.com/install-adb-windows-macos-linux/
 

--- a/11/crosshatch.md
+++ b/11/crosshatch.md
@@ -1,3 +1,5 @@
+GApps are **NOT** supported! The Pixel 3 XL's partitions are too small to store both crDroid and GApps. Installing GApps will result in your phone bootlooping, and support will not be provided if you attempt to install them.
+
 ### Pre-installation:
 You will need to have a computer with the Android Platform Tools installed. See XDA's guide for installing the platform tools: https://www.xda-developers.com/install-adb-windows-macos-linux/
 

--- a/11/sargo.md
+++ b/11/sargo.md
@@ -1,3 +1,5 @@
+GApps are **NOT** supported! The Pixel 3 XL's partitions are too small to store both crDroid and GApps. Installing GApps will result in your phone bootlooping, and support will not be provided if you attempt to install them.
+
 ### Pre-installation:
 You will need to have a computer with the Android Platform Tools installed. See XDA's guide for installing the platform tools: https://www.xda-developers.com/install-adb-windows-macos-linux/
 


### PR DESCRIPTION
This is already pretty clearly stated in the XDA thread, but people still attempt to ask for help regarding GApps. Adding to install_docs to clarify again.