### PR TITLE
Update and clarify instructions for A52 4G and A72.

### DIFF
--- a/12/a52q.md
+++ b/12/a52q.md
@@ -15,16 +15,16 @@
 3. Power off the phone, then enter **Download Mode** using **Volume Down + Volume Up**, and open **Odin3**.  
 4. Remove the date prefix from the recovery image file. The final file should be named:
 
-    ```
-    recovery.img
-    ```
-5. Compress the recovery image to `.tar` format:
+```
+recovery.img
+```
+5. Compress the recovery image to ***.tar*** format:
 
-    ```bash
-    tar --format=ustar -cvf recovery.tar recovery.img
-    ```
+```
+tar --format=ustar -cvf recovery.tar recovery.img
+```
 6. In Odin3:  
-   - Select the recovery `.tar` file in the **AP** slot.  
+   - Select the recovery ***.tar*** file in the **AP** slot.  
    - Select the VBMETA file in the **USERDATA** slot.  
    - Disable **Auto-Reboot** in Odin3 settings.  
    - Click **Start**.  
@@ -36,9 +36,9 @@
    - Click **Apply Update**, then **Apply from ADB**.  
 10. On your PC, run:
 
-    ```bash
-    adb sideload crdroid.zip
-    ```
+```
+adb sideload crdroid.zip
+```
 11. Repeat the same steps for any additional packages.  
 12. Reboot the device and enjoy crDroid!  
 

--- a/12/a52q.md
+++ b/12/a52q.md
@@ -1,34 +1,53 @@
-### Pre-installation:
+## Pre-installation
 
-* Must have Android 14 OneUI 6/6.1 before the install
-* Recovery (from download page, recovery button)
-* Optional gapps (from download page, gapps button)
-* Odin3 [Download](https://undocumented.software/Odin_3.13.1.zip)
-* Disabled VBMETA [Download](https://downloads.simon1511.de/s/9d8iJQ6L83eSNAL)
+- Must have **Android 14 OneUI 6/6.1** before the install.  
+- **Recovery** (from download page, recovery button).  
+- Optional **GApps** (from download page, GApps button).  
+- **Odin3** [Download](https://undocumented.software/Odin_3.13.1.zip)  
+- **Disabled VBMETA** [Download](https://downloads.simon1511.de/s/9d8iJQ6L83eSNAL)  
 
+---
 
-### First time installation (clean flash):
+## First-time installation (clean flash)
 
-* Remove all Google accounts from your device to avoid FRP (Factory reset protection).
-* Backup Data if needed.
-* Power off the phone, then enter Download Mode using Volume Down + Volume Up and enter Odin3.
-* In Odin3, select recovery file in the AP slot, and the VBMETA in USERDATA slot, then disable auto-reboot in Odin3 settings, then click start.
-* After the flash is done, hold Volume Down + Power until it reboots, then Volume Up + Power until in recovery.
-* In crDroid recovery, select Factory reset, then Format data/factory reset.
-* After it's done, click on advanced, then reboot recovery.
-* Back in recovery, click Apply Update, then Apply from ADB.
-* Then put this command on your PC to install the crDroid rom:
+1. Remove all Google accounts from your device to avoid **FRP** (Factory Reset Protection).  
+2. Backup your data if needed.  
+3. Power off the phone, then enter **Download Mode** using **Volume Down + Volume Up**, and open **Odin3**.  
+4. Remove the date prefix from the recovery image file. The final file should be named:
 
-```
-adb sideload crdroid.zip
-```
-* After it's done, do the same steps to install any additional packages.
-* Reboot and enjoy.
+    ```
+    recovery.img
+    ```
+5. Compress the recovery image to `.tar` format:
 
-### Update installation:
+    ```bash
+    tar --format=ustar -cvf recovery.tar recovery.img
+    ```
+6. In Odin3:  
+   - Select the recovery `.tar` file in the **AP** slot.  
+   - Select the VBMETA file in the **USERDATA** slot.  
+   - Disable **Auto-Reboot** in Odin3 settings.  
+   - Click **Start**.  
+7. After flashing, hold **Volume Down + Power** until the phone reboots, then **Volume Up + Power** to enter recovery.  
+8. In **crDroid Recovery**:  
+   - Select **Factory Reset**, then **Format Data / Factory Reset**.  
+   - After it’s done, click **Advanced**, then **Reboot Recovery**.  
+9. Back in recovery:  
+   - Click **Apply Update**, then **Apply from ADB**.  
+10. On your PC, run:
 
-* Go to the system updater in the Settings app, and download the new update.
-* After the download is done, the update will be done automatically. 
-* Reboot.
+    ```bash
+    adb sideload crdroid.zip
+    ```
+11. Repeat the same steps for any additional packages.  
+12. Reboot the device and enjoy crDroid!  
 
-NOTE: If after OTA, some additional packages you had installed (e.g Magisk) are not there anymore, reflash them in recovery with ADB.
+---
+
+## Update installation
+
+1. Go to **Settings → System Updater** and download the new update.  
+2. The update will install automatically after download.  
+3. Reboot the device.  
+
+**Note:** If after the OTA update some additional packages you installed (e.g., Magisk) are missing, reflash them in recovery via ADB.

--- a/12/a72q.md
+++ b/12/a72q.md
@@ -1,34 +1,53 @@
-### Pre-installation:
+## Pre-installation
 
-* Must have Android 14 OneUI 6/6.1 before the install
-* Recovery (from download page, recovery button)
-* Optional gapps (from download page, gapps button)
-* Odin3 [Download](https://undocumented.software/Odin_3.13.1.zip)
-* Disabled VBMETA [Download](https://downloads.simon1511.de/s/9d8iJQ6L83eSNAL)
+- Must have **Android 14 OneUI 6/6.1** before the install.  
+- **Recovery** (from download page, recovery button).  
+- Optional **GApps** (from download page, GApps button).  
+- **Odin3** [Download](https://undocumented.software/Odin_3.13.1.zip)  
+- **Disabled VBMETA** [Download](https://downloads.simon1511.de/s/9d8iJQ6L83eSNAL)  
 
+---
 
-### First time installation (clean flash):
+## First-time installation (clean flash)
 
-* Remove all Google accounts from your device to avoid FRP (Factory reset protection).
-* Backup Data if needed.
-* Power off the phone, then enter Download Mode using Volume Down + Volume Up and enter Odin3.
-* In Odin3, select recovery file in the AP slot, and the VBMETA in USERDATA slot, then disable auto-reboot in Odin3 settings, then click start.
-* After the flash is done, hold Volume Down + Power until it reboots, then Volume Up + Power until in recovery.
-* In crDroid recovery, select Factory reset, then Format data/factory reset.
-* After it's done, click on advanced, then reboot recovery.
-* Back in recovery, click Apply Update, then Apply from ADB.
-* Then put this command on your PC to install the crDroid rom:
+1. Remove all Google accounts from your device to avoid **FRP** (Factory Reset Protection).  
+2. Backup your data if needed.  
+3. Power off the phone, then enter **Download Mode** using **Volume Down + Volume Up**, and open **Odin3**.  
+4. Remove the date prefix from the recovery image file. The final file should be named:
 
-```
-adb sideload crdroid.zip
-```
-* After it's done, do the same steps to install any additional packages.
-* Reboot and enjoy.
+    ```
+    recovery.img
+    ```
+5. Compress the recovery image to `.tar` format:
 
-### Update installation:
+    ```bash
+    tar --format=ustar -cvf recovery.tar recovery.img
+    ```
+6. In Odin3:  
+   - Select the recovery `.tar` file in the **AP** slot.  
+   - Select the VBMETA file in the **USERDATA** slot.  
+   - Disable **Auto-Reboot** in Odin3 settings.  
+   - Click **Start**.  
+7. After flashing, hold **Volume Down + Power** until the phone reboots, then **Volume Up + Power** to enter recovery.  
+8. In **crDroid Recovery**:  
+   - Select **Factory Reset**, then **Format Data / Factory Reset**.  
+   - After it’s done, click **Advanced**, then **Reboot Recovery**.  
+9. Back in recovery:  
+   - Click **Apply Update**, then **Apply from ADB**.  
+10. On your PC, run:
 
-* Go to the system updater in the Settings app, and download the new update.
-* After the download is done, the update will be done automatically. 
-* Reboot.
+    ```bash
+    adb sideload crdroid.zip
+    ```
+11. Repeat the same steps for any additional packages.  
+12. Reboot the device and enjoy crDroid!  
 
-NOTE: If after OTA, some additional packages you had installed (e.g Magisk) are not there anymore, reflash them in recovery with ADB.
+---
+
+## Update installation
+
+1. Go to **Settings → System Updater** and download the new update.  
+2. The update will install automatically after download.  
+3. Reboot the device.  
+
+**Note:** If after the OTA update some additional packages you installed (e.g., Magisk) are missing, reflash them in recovery via ADB.


### PR DESCRIPTION
I updated the formatting a bit to be easier to follow, and also added instructions on how to compress the recovery img file to tar, beacuse they were missing and needed for installation.