### PR TITLE
peridot: update installation instructions to follow LineageOS flashin…

### DIFF
--- a/12/peridot.md
+++ b/12/peridot.md
@@ -1,6 +1,6 @@
 ### Pre-installation:
 
-* **HyperOS latest stable based on Android 15 firmware is required. As of now: Global OS3.0.6.0.WNPMIXM**
+* **HyperOS latest stable  firmware is required. As of now: Global OS3.0.6.0.WNPMIXM**
 * Optional GApps (available from the download page)
 
 ### First time installation (clean flash):

--- a/12/peridot.md
+++ b/12/peridot.md
@@ -1,31 +1,86 @@
 ### Pre-installation:
 
-* **HyperOS latest stable based on Android 15 firmware is required As of now Global HOS OS OS3.0.6.0.WNPMIXM **
-* Optional gapps (from download page, gapps button)
-
+* **HyperOS latest stable based on Android 15 firmware is required. As of now: Global OS3.0.6.0.WNPMIXM**
+* Optional GApps (available from the download page)
 
 ### First time installation (clean flash):
-* Boot to recovery
-* Flash the provided recovery image and vendor boot image via fastboot using ***fastboot flash recovery recover.img*** & ***fastboot flash vendor_boot vendor_boot.img***
-* Reboot to recovery using either volume + and power button combo or via fastboot command
-* Navigate to Apply Update > Apply from ADB
-* adb sideload the lineage zip using "adb sideload crdroid-*-peridot.zip"
-* Factory reset/format data
-* Reboot to system
-* In case you want to use your own google apps package nikkaGapps is recomended, you can install this by rebooting back into recovery after step 4
+
+* Download all required files from the official recovery folder.
+
+* Power off the device and boot into Fastboot mode:
+  * Hold **Volume Down + Power** until **FASTBOOT** appears on the screen.
+
+* Flash the required images:
+
+```bash
+fastboot flash boot boot.img
+fastboot flash dtbo dtbo.img
+fastboot flash init_boot init_boot.img
+fastboot flash vendor_boot vendor_boot.img
+fastboot flash recovery recovery.img
+```
+
+* Reboot into recovery:
+
+```bash
+fastboot reboot recovery
+```
+
+* If the device does not boot into recovery automatically:
+  * Power off the device.
+  * Hold **Volume Up + Power** until the **MI** logo appears, then release.
+
+> **Note:** Touch input works in recovery on most devices. If touch does not work, use the Volume keys to navigate and the Power button to select options.
+
+* In recovery, select:
+  * **Factory Reset**
+  * **Format data / factory reset**
+  * Confirm the formatting process.
+
+> This removes encryption, wipes internal storage, and formats the cache partition (if present).
+
+* Return to the main menu and navigate to:
+  * **Apply Update**
+  * **Apply from ADB**
+
+* Sideload the ROM:
+
+```bash
+adb sideload crDroid-*-peridot.zip
+```
+
+> **Note:** The sideload process may stop at around 47% on the host computer. This is expected behavior and not a failure.
+
+* Reboot to system.
+
+* If you want to use your own Google Apps package (NikGApps recommended):
+  * Reboot back into recovery after ROM installation.
+  * Sideload the GApps package.
+  * Reboot to system.
 
 ### Update installation:
-#### Via recovery (recommended way):
-* Boot to recovery
-* Choose apply update and Apply from ADB
-* Now install crDroid zip via sideload and reboot
 
-```
+#### Via recovery (recommended way):
+
+* Boot to recovery.
+* Navigate to **Apply Update → Apply from ADB**.
+* Install the latest crDroid build:
+
+```bash
 adb sideload crDroid.zip
 ```
-* If you had gapps, reboot to recovery and sideload gapps.zip and reboot
+
+* If you use GApps, reboot back into recovery and sideload the GApps package.
+* Reboot to system.
 
 #### Via OTA:
-* Go to Settings -> System -> Updater and download latest build
-* Choose install and let it finish
-* Reboot
+
+* Go to **Settings → System → Updater**.
+* Download the latest build.
+* Select **Install** and wait for the process to finish.
+* Reboot.
+
+### Notes:
+
+* Do **not** flash firmware separately. The required firmware components are already included in the ROM package.
+* Before reporting installation issues, ensure that all steps above were followed exactly as documented.

--- a/12/peridot.md
+++ b/12/peridot.md
@@ -1,86 +1,65 @@
-### Pre-installation:
-
-* **HyperOS latest stable  firmware is required. As of now: Global OS3.0.6.0.WNPMIXM**
+## Pre-installation
+* HyperOS latest stable firmware is required. As of now: Global OS3.0.6.0.WNPMIXM
 * Optional GApps (available from the download page)
 
-### First time installation (clean flash):
-
+## First time installation (clean flash)
 * Download all required files from the official recovery folder.
-
 * Power off the device and boot into Fastboot mode:
-  * Hold **Volume Down + Power** until **FASTBOOT** appears on the screen.
-
-* Flash the required images:
-
-```bash
-fastboot flash boot boot.img
-fastboot flash dtbo dtbo.img
-fastboot flash init_boot init_boot.img
-fastboot flash vendor_boot vendor_boot.img
-fastboot flash recovery recovery.img
-```
-
-* Reboot into recovery:
-
-```bash
-fastboot reboot recovery
-```
-
+  * Hold Volume Down + Power until FASTBOOT appears on the screen.
+    
+ ## Flash the required images:
+  * fastboot flash boot boot.img
+  * fastboot flash dtbo dtbo.img
+  * fastboot flash init_boot init_boot.img
+  * fastboot flash vendor_boot vendor_boot.img
+  * fastboot flash recovery recovery.img
+ 
+## Reboot into recovery:
+  * fastboot reboot recovery
 * If the device does not boot into recovery automatically:
   * Power off the device.
-  * Hold **Volume Up + Power** until the **MI** logo appears, then release.
+  * Hold Volume Up + Power until the MI logo appears, then release.
 
-> **Note:** Touch input works in recovery on most devices. If touch does not work, use the Volume keys to navigate and the Power button to select options.
+> Note: Touch input works in recovery on most devices. If touch does not work, use the Volume keys to navigate and the Power button to select options.
 
-* In recovery, select:
-  * **Factory Reset**
-  * **Format data / factory reset**
+## In recovery, select:
+  * Factory Reset
+  * Format data / factory reset
   * Confirm the formatting process.
 
 > This removes encryption, wipes internal storage, and formats the cache partition (if present).
 
-* Return to the main menu and navigate to:
-  * **Apply Update**
-  * **Apply from ADB**
-
+## Return to the main menu and navigate to:
+  * Apply Update
+  * Apply from ADB
 * Sideload the ROM:
+  * adb sideload crDroid-*-peridot.zip
 
-```bash
-adb sideload crDroid-*-peridot.zip
-```
+> Note: The sideload process may stop at around 47% on the host computer. This is expected behavior and not a failure.
 
-> **Note:** The sideload process may stop at around 47% on the host computer. This is expected behavior and not a failure.
-
-* Reboot to system.
-
+## Reboot to system.
 * If you want to use your own Google Apps package (NikGApps recommended):
   * Reboot back into recovery after ROM installation.
   * Sideload the GApps package.
   * Reboot to system.
 
-### Update installation:
+## Update installation
 
-#### Via recovery (recommended way):
-
+### Via recovery (recommended way)
 * Boot to recovery.
-* Navigate to **Apply Update → Apply from ADB**.
+* Navigate to Apply Update -> Apply from ADB.
 * Install the latest crDroid build:
-
-```bash
-adb sideload crDroid.zip
-```
-
+  * adb sideload crDroid.zip
 * If you use GApps, reboot back into recovery and sideload the GApps package.
 * Reboot to system.
 
-#### Via OTA:
-
-* Go to **Settings → System → Updater**.
+### Via OTA
+* Go to Settings -> System -> Updater.
 * Download the latest build.
-* Select **Install** and wait for the process to finish.
+* Select Install and wait for the process to finish.
 * Reboot.
 
-### Notes:
-
-* Do **not** flash firmware separately. The required firmware components are already included in the ROM package.
+## Notes
+* Do not flash firmware separately. The required firmware components are already included in the ROM package.
 * Before reporting installation issues, ensure that all steps above were followed exactly as documented.
+* 


### PR DESCRIPTION
…g flow

The device is now fully based on the LineageOS device tree.

Update the installation guide to follow the latest LineageOS flashing procedure, including flashing boot, dtbo, init_boot, vendor_boot and recovery images before sideloading the ROM.

This change improves consistency with upstream documentation and helps reduce user confusion during installation.