### PR TITLE
chime: fix flashing instructions

### DIFF
--- a/12/chime.md
+++ b/12/chime.md
@@ -15,21 +15,25 @@
 ```
 fastboot flash boot boot.img
 ```
+
 * Flash the DTBO image:
 
 ```
 fastboot flash dtbo dtbo.img
 ```
+
 Flash the recovery image:
 
 ```
 fastboot flash recovery recovery.img
 ```
+
 * Reboot to recovery:
 
 ```
 fastboot reboot recovery
 ```
+
 * In recovery mode, navigate to **Factory reset -> Format data/factory reset** and confirm to format the device.
 * After formatting, return to the main menu and navigate to **Apply update -> Apply from ADB**.
 * Sideload the ROM:
@@ -37,11 +41,14 @@ fastboot reboot recovery
 ```
 adb sideload crdroid.zip (replace "crdroid" with actual filename)
 ```
+
 * Reboot to recovery to sideload any add-ons (e.g., Magisk, GApps, Firmware etc).
 * Finally, reboot to the system.
 
 ### Update installation:
+
 #### Via recovery (recommended way):
+
 * Boot to recovery
 * Choose apply update and Apply from ADB
 * Now install crDroid zip via sideload and reboot
@@ -51,8 +58,8 @@ adb sideload crDroid.zip
 ```
 
 #### Via OTA:
+
 * Go to Settings -> System -> Updater and download latest build
 * Choose install and let it finish
 * If having gapps, reboot to recovery and sideload gapps package again
 * Reboot
-

--- a/12/chime.md
+++ b/12/chime.md
@@ -10,20 +10,20 @@
 
 * Unlock Bootloader
 * Reboot to bootloader
-* Flash the vendor boot image:
+* Flash the boot image:
 
 ```
-fastboot flash vendor_boot vendor_boot.img
+fastboot flash boot boot.img
 ```
 * Flash the DTBO image:
 
 ```
 fastboot flash dtbo dtbo.img
 ```
-Flash the boot image:
+Flash the recovery image:
 
 ```
-fastboot flash boot boot.img
+fastboot flash recovery recovery.img
 ```
 * Reboot to recovery:
 


### PR DESCRIPTION
Hello, there is no `vendor_boot` available for download neither this device uses `vendor_boot`. The `chime` devices do not have GKI as per [this xda post](https://xdaforums.com/t/rom-16-0-official-chime-crdroid-v12-5-20-01-2026.4776195/#post-90539938).