### PR TITLE
a71: update to use crDroid's recovery and support Linux installation

### DIFF
--- a/12/a71.md
+++ b/12/a71.md
@@ -1,8 +1,15 @@
 ### Prerequisites
 * Your Samsung Galaxy A71
 * USB-C cable that can do data transfer  
-* A computer running Windows 10 or later which has ADB installed
+* A computer with ADB installed running Windows 10 or later or Linux
 
+### Pre-installation:
+* Download the latest ROM file (referred to as **crdroid.zip**).
+* Download support files from the site:
+  - **recovery.img**
+  - **vbmeta.img**
+* Download the latest GApps (referred to as **gapps.zip**).
+* Ensure you are on latest available firmware for your device.
 
 ### Unlocking bootloader
 This **WILL** factory reset your phone. Back up any data before continuing.  
@@ -16,28 +23,29 @@ This **WILL** factory reset your phone. Back up any data before continuing.
 * Hold down volume up until it says "Unlock bootloader?", then press volume up again.  
 
 ### Installing TWRP
-You will have to install Odin and the Samsung USB drivers on a computer, which requires Windows XP or later.  
+You will have to install Odin and the Samsung USB drivers on a computer, which requires Windows XP or
+later, or you can do it from heimdall (latest version or at least 2.0.2) under Linux.
 * Turn the phone off  
 * Hold down volume down and volume up and plug the phone into your computer.  
 * When the Warning screen appears, let go of all buttons.  
-* Press volume up to enter download mode.  
-* Get recovery.tar from [https://sourceforge.net/projects/intelgigabyte-9299/files/twrp-3.7.0_11-3_afaneh92-a71.tar/download](https://sourceforge.net/projects/intelgigabyte-9299/files/twrp-3.7.0_11-3_afaneh92-a71.tar/download).  
-* Open Odin, and select the tar file you just downloaded for AP.
-* Select Options To disable auto reboot in ODIN  
-* Select VBMeta into UserData 
-* Download [https://xdaforums.com/attachments/vbmeta_disabled-tar.5371913/?hash=4ffe83be111a345e3fb35895ba1a5995](https://xdaforums.com/attachments/vbmeta_disabled-tar.5371913/?hash=4ffe83be111a345e3fb35895ba1a5995) 
-* Press "Start"
-* When the phone reboots, hold down volume up and power until it boots into TWRP
+* Press volume up to enter download mode.
+* Get recovery.img and vbmeta.img from the download section.
+* For heimdall you must run: heimdall flash --VBMETA vbmeta.img --RECOVERY recovery.img
+* For Odin you must pack both files on a plain tar file and then select that tar for AP. Go to "Options", and verify "Re-Partition" is unchecked. Having it checked may result in a brick. Then "Start"
+* When the phone reboots, hold down volume up and power until it boots into recovery
 
 ### Installing crDroid
-* Download the latest crDroid build from download page  
-* In TWRP, press "Wipe", then "Advanced Wipe"  
-* Select "System", "Data", "Cache", and "Dalvik / ART Cache"  
-* Swipe to wipe  
-* Go back to TWRP's main menu  
-* Press "Advanced", "ADB Sideload"
-* Swipe to sideload
-* On your computer, run "adb sideload [path to crdroid.zip]".
-* If wanted, you can also install GApps.
+* From crDroid recovery (you can enter it by pressing Vol Up + Power buttons with the device connected to your USB port.).
+* Run "Factory reset" > "Format data/factory reset" > "Format Data" and "Format system partition".
+* Tap on "Apply Update" > "Apply from ADB".
+* On your PC, open terminal and type the following command to flash;
+
+```
+adb sideload crdroid.zip
+```
+
+* Do the sideload steps for gapps and whatever extra thinks you want to install too.
+* Enjoy the fun ...
+
 
 On first boot, the phone may remain on the Samsung Galaxy A71 logo for several minutes, this is normal and only happens on first boot, however in some rare cases, the phone will hang. If the phone doesn't go past the Galaxy A71 logo after 15 minutes, hold down power+volume down to reboot the phone, afterwards it will boot.  


### PR DESCRIPTION
Updating a71 doc to stop using twrp and use crDroid's recovery and more.